### PR TITLE
Add audio synthesis feature and related specs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,13 @@ group :development do
   # gem "spring"
 end
 
-gem "google-cloud-text_to_speech"
+group :test do
+  gem 'vcr'
+  gem 'webmock'
+end
 
-gem "figaro"
+gem 'google-cloud-text_to_speech'
+
+gem 'figaro'
+gem 'activeinteractor', require: 'active_interactor'
+gem 'pry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,6 +51,9 @@ GEM
       activemodel (>= 4.1)
       case_transform (>= 0.2)
       jsonapi-renderer (>= 0.1.1.beta1, < 0.3)
+    activeinteractor (1.2.1)
+      activemodel (>= 4.2, < 8)
+      activesupport (>= 4.2, < 8)
     activejob (7.0.8)
       activesupport (= 7.0.8)
       globalid (>= 0.3.6)
@@ -79,7 +82,10 @@ GEM
     builder (3.2.4)
     case_transform (0.2)
       activesupport
+    coderay (1.1.3)
     concurrent-ruby (1.2.2)
+    crack (0.4.5)
+      rexml
     crass (1.0.6)
     date (3.3.3)
     debug (1.8.0)
@@ -143,6 +149,7 @@ GEM
     grpc (1.59.2)
       google-protobuf (~> 3.24)
       googleapis-common-protos-types (~> 1.0)
+    hashdiff (1.0.1)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     io-console (0.6.0)
@@ -181,6 +188,9 @@ GEM
       racc (~> 1.4)
     os (1.1.4)
     pg (1.5.4)
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     psych (5.1.1.1)
       stringio
     public_suffix (5.0.3)
@@ -225,6 +235,7 @@ GEM
       psych (>= 4.0.0)
     reline (0.3.9)
       io-console (~> 0.5)
+    rexml (3.2.6)
     rspec-core (3.12.2)
       rspec-support (~> 3.12.0)
     rspec-expectations (3.12.3)
@@ -267,6 +278,11 @@ GEM
     timeout (0.4.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    vcr (6.1.0)
+    webmock (3.8.3)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -277,18 +293,22 @@ PLATFORMS
 
 DEPENDENCIES
   active_model_serializers
+  activeinteractor
   bootsnap
   debug
   factory_bot_rails
   figaro
   google-cloud-text_to_speech
   pg (~> 1.1)
+  pry
   puma (~> 5.0)
   rack-cors
   rails (~> 7.0.8)
   rspec-rails
   rswag
   tzinfo-data
+  vcr
+  webmock
 
 RUBY VERSION
    ruby 3.1.4p223

--- a/app/interactors/subject/manage_audio_synthesis.rb
+++ b/app/interactors/subject/manage_audio_synthesis.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class Subject::ManageAudioSynthesisContext < ActiveInteractor::Context::Base
+  attributes :subject
+
+  validates :subject, presence: true, on: :calling
+end
+
+class Subject::ManageAudioSynthesis < ActiveInteractor::Organizer::Base
+  organize do
+    add SynthesizeAudio, before: -> { context.text = context[:subject].body }
+    add Subject::SaveAudioToSubject
+  end
+end

--- a/app/interactors/subject/save_audio_to_subject.rb
+++ b/app/interactors/subject/save_audio_to_subject.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class Subject::SaveAudioToSubjectContext < ActiveInteractor::Context::Base
+  attributes :subject, :audio
+
+  validates :subject, :audio, presence: true, on: :calling
+end
+
+class Subject::SaveAudioToSubject < ActiveInteractor::Base
+  def perform
+    attach_audio_to_subject
+
+    unless context.subject.save
+      context.fail!(message: 'Failed to save audio to subject')
+    end
+  end
+
+  private
+
+  def attach_audio_to_subject
+    context.subject.body_audio.attach(
+      io: StringIO.new(context.audio),
+      filename:,
+      content_type: 'audio/mpeg'
+    )
+  end
+
+  def filename
+    "#{context[:subject].id}_#{Time.now.to_i}.mp3"
+  end
+end

--- a/app/interactors/synthesize_audio.rb
+++ b/app/interactors/synthesize_audio.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class SynthesizeAudioContext < ActiveInteractor::Context::Base
+  attributes :text, :audio
+
+  validates :text, presence: true, on: :calling
+end
+
+class SynthesizeAudio < ActiveInteractor::Base
+  def perform
+    context.audio = GoogleTextToSpeechService.new(context.text).synthesize_speech
+  end
+end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -54,7 +54,11 @@ Rails.application.configure do
 
   # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true
-
+  VCR.configure do |config|
+    config.cassette_library_dir = "spec/vcr_cassettes"
+    config.hook_into :webmock # or :fakeweb
+    config.configure_rspec_metadata!
+  end
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
 end

--- a/spec/interactors/subjects/manage_audio_synthesis_spec.rb
+++ b/spec/interactors/subjects/manage_audio_synthesis_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Subject::ManageAudioSynthesis, vcr: { record: :none } do
+  let(:test_subject) { create(:subject) }
+
+  let(:interactor) do
+    described_class.perform(subject: test_subject)
+  end
+
+  it 'attaches synthesized audio to the subject', vcr_cassette: 'Subject/manage_audio_synthesis' do
+    expect(interactor.success?).to be(true)
+    expect(test_subject.body_audio).to be_attached
+  end
+end

--- a/spec/interactors/subjects/save_audio_to_subject_spec.rb
+++ b/spec/interactors/subjects/save_audio_to_subject_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Subject::SaveAudioToSubject, type: :interactor do
+  let(:test_subject) { create(:subject) }
+  let(:audio_data) { 'mocked_audio_data' }
+  let(:interactor) { described_class.perform(subject: test_subject, audio: audio_data) }
+
+  before { interactor }
+
+  describe 'attaching audio' do
+    it 'successfully attaches audio to the subject' do
+      expect(interactor.success?).to be(true)
+      expect(test_subject.body_audio).to be_attached
+    end
+
+    it 'uses the correct naming convention for the attached file' do
+      filename = test_subject.body_audio.filename.to_s
+      expect(filename).to match(/#{test_subject.id}_\d+\.mp3/)
+    end
+  end
+end

--- a/spec/interactors/synthesize_audio_spec.rb
+++ b/spec/interactors/synthesize_audio_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SynthesizeAudio, type: :interactor, vcr: { record: :none }  do
+  let(:text) { 'Hello, World!' }
+
+  let(:interactor) do
+    described_class.perform(text: text)
+  end
+
+  it 'synthesizes the audio', vcr_cassette: 'GoogleTextToSpeechService/synthesize_speech' do
+    expect(GoogleTextToSpeechService).to receive(:new).with(text).and_call_original
+
+    expect(interactor.success?).to be(true)
+    expect(interactor.audio).to be_present
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -56,6 +56,7 @@ RSpec.configure do |config|
   # https://rspec.info/features/6-0/rspec-rails
   config.infer_spec_type_from_file_location!
 
+  config.include FactoryBot::Syntax::Methods
   # Filter lines from Rails gems in backtraces.
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:


### PR DESCRIPTION
Implemented the audio synthesis feature, which allows system to synthesize audio from the subject body text and attach it to the subject. This includes necessary interactors for synthesizing audio, managing audio synthesis for a subject, and saving audio to the subject. Also added relative spec files for each of these interactors.

Additional changes include the addition of various gems required for this feature such as ‘vcr’, 'webmock', 'activeinteractor', 'pry' and updates in rails_helper, Gemfile and test environment configurations.

This feature gives system the capability to generate audio from text, which might enhance the user experience by providing an alternative, auditory way to digest information.