### PR TITLE
Add transcription support to audio synthesis process

### DIFF
--- a/app/interactors/get_audio_transcription.rb
+++ b/app/interactors/get_audio_transcription.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class GetAudioTranscriptionContext < ActiveInteractor::Context::Base
+  attributes :audio_blob, :transcription
+
+  validates :audio_blob, presence: true, on: :calling
+end
+
+class GetAudioTranscription < ActiveInteractor::Base
+  def perform
+    service = WhisperService.new
+    context.transcription = service.transcript_audio(context.audio_blob)
+  end
+end

--- a/app/interactors/subject/manage_audio_synthesis_organizer.rb
+++ b/app/interactors/subject/manage_audio_synthesis_organizer.rb
@@ -11,11 +11,17 @@ class Subject::ManageAudioSynthesisOrganizer < ActiveInteractor::Organizer::Base
     add Subject::CreateSubject
     add SynthesizeAudio, before: -> { synthesize_audio_context }
     add Subject::SaveAudioToSubject
+    add GetAudioTranscription, before: -> { get_audio_transcription_context }
+    add Subject::SaveTranscription
   end
 
   private
   def synthesize_audio_context
     context.text = context[:subject].body
     context.filename = "#{context[:subject].id}_#{Time.now.to_s}"
+  end
+
+  def get_audio_transcription_context
+    context.audio_blob = context[:subject].body_audio.blob
   end
 end

--- a/app/interactors/subject/save_transcription.rb
+++ b/app/interactors/subject/save_transcription.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class Subject::SaveTranscriptionContext < ActiveInteractor::Context::Base
+  attributes :subject, :transcription
+
+  validates :subject, :transcription, presence: true, on: :calling
+end
+
+class Subject::SaveTranscription < ActiveInteractor::Base
+  def perform
+    unless context[:subject].update(body_transcription: preperad_transcription)
+      context.fail!(message: 'Failed to save transcription to subject')
+    end
+  end
+
+  private
+  def preperad_transcription
+    transcriptions = context[:transcription].flatten!
+    transcriptions.each do |transcription|
+      transcription[:start] = (transcription[:start] * 1000).to_i
+      transcription[:end] = (transcription[:end] * 1000).to_i
+    end
+  end
+end

--- a/app/serializers/subject_serializer.rb
+++ b/app/serializers/subject_serializer.rb
@@ -1,7 +1,7 @@
 class SubjectSerializer < ActiveModel::Serializer
   include Rails.application.routes.url_helpers
 
-  attributes :id, :title, :body, :summary, :body_audio_url, :estimate_reading_time, :body_audio_duration
+  attributes :id, :title, :body, :summary, :body_audio_url, :estimate_reading_time, :body_audio_duration, :body_transcription
 
   def body_audio_url
     rails_blob_url(object.body_audio, only_path: true) if object.body_audio.attached?


### PR DESCRIPTION
Added functionality to the synthesizing process to include the transcribing of audio files. The update introduces two new interactors Subject::SaveTranscription and GetAudioTranscription that handle the transcription related operations after synthesizing audio. Both interactors are added to the manage_audio_synthesis_organizer ensuring a seamless transition in the current audio synthesis process. 'body_transcription' field is also introduced to SubjectSerializer to reflect this change. This new change can aid in the accessibility of the content providing a textual copy of audio files for those who require it.